### PR TITLE
fix dev build docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,9 +27,14 @@ RUN git clone https://github.com/bitcoin-core/secp256k1 && \
 
 RUN ln -s /usr/local/lib/libsecp256k1.so.0 /usr/lib/libsecp256k1.so.0
 
-RUN wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage && \
-    chmod +x linuxdeploy-x86_64.AppImage                                                                     && \
-    mv linuxdeploy-x86_64.AppImage /usr/bin                                                                  && \
-    wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage   && \
-    chmod +x appimagetool-x86_64.AppImage                                                                    && \
-    mv appimagetool-x86_64.AppImage /usr/bin
+# install linuxdeploy and workaround AppImage issues with docker
+RUN wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage -O /opt/linuxdeploy-x86_64.AppImage                  && \
+    cd /opt/; chmod +x linuxdeploy-x86_64.AppImage; sed -i 's|AI\x02|\x00\x00\x00|' linuxdeploy-x86_64.AppImage; ./linuxdeploy-x86_64.AppImage --appimage-extract && \
+    mv /opt/squashfs-root /opt/linuxdeploy-x86_64.AppImage.AppDir                                                                                                 && \
+    ln -s /opt/linuxdeploy-x86_64.AppImage.AppDir/AppRun /usr/bin/linuxdeploy-x86_64.AppImage
+
+# install appimagetool and workaround AppImage issues with docker
+RUN wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O /opt/appimagetool-x86_64.AppImage                  && \
+    cd /opt/; chmod +x appimagetool-x86_64.AppImage; sed -i 's|AI\x02|\x00\x00\x00|' appimagetool-x86_64.AppImage; ./appimagetool-x86_64.AppImage --appimage-extract && \
+    mv /opt/squashfs-root /opt/appimagetool-x86_64.AppImage.AppDir                                                                                                 && \
+    ln -s /opt/appimagetool-x86_64.AppImage.AppDir/AppRun /usr/bin/appimagetool-x86_64.AppImage

--- a/build-appimage.sh
+++ b/build-appimage.sh
@@ -3,4 +3,4 @@
 cp -R assets futr.AppDir/usr/bin
 cp assets/icons/futr-icon.png futr.AppDir
 APPIMAGE_EXTRACT_AND_RUN=1 linuxdeploy-x86_64.AppImage --appdir futr.AppDir
-ARCH=x86_64 appimagetool-x86_64.AppImage futr.AppDir --appimage-extract-and-run
+ARCH=x86_64 appimagetool-x86_64.AppImage futr.AppDir

--- a/devbuild.sh
+++ b/devbuild.sh
@@ -1,3 +1,7 @@
 #!/bin/sh
+RUN="docker run -it -v ${PWD}:/app -w /app prolic/futr-dev:latest"
 stack build --copy-bins --local-bin-path futr.AppDir/usr/bin
-docker run -it -v ${PWD}:/app -w /app prolic/futr-dev:latest ./build-appimage.sh
+$RUN cp -R assets futr.AppDir/usr/bin
+$RUN cp assets/icons/futr-icon.png futr.AppDir
+$RUN linuxdeploy-x86_64.AppImage --appdir futr.AppDir
+ARCH=x86_64 $RUN appimagetool-x86_64.AppImage futr.AppDir


### PR DESCRIPTION
resolves https://github.com/prolic/futr/issues/1

two lines on any linux machine that has docker installed are sufficient:

```bash
curl -sSL https://get.haskellstack.org/ | sh
./devbuild.sh
```

On the first run you have to wait a little bit. Then you'll receive a new file:

```bash
./futr-x86_64.AppImage
```

Feel free to copy this file into any directory that is part of your $PATH (f.e. /usr/bin).